### PR TITLE
Add a link for the source of the table of stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,6 +162,9 @@
         </table>
       </div>
     </div>
+    <div class="col s12 facts">
+      <a target="_blank" href="http://vt.ncsbe.gov/voter_stats/results.aspx?date=12-31-2016">Table data source</a>
+    </div>
 
     <!--- Resources -->
     <div class="row">


### PR DESCRIPTION
Add a link for the source of the table of stats.
Link is below the tables, left-aligned.